### PR TITLE
[GFSB-2268] update container datadog-agent/datadog-agent

### DIFF
--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -7,9 +7,9 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  AGENT_VERSION: 7.57.2
-  CLUSTER_AGENT_IMAGE_NAME: "${{ github.repository }}/datadog-cluster-agent:${{ github.sha }}-7.57.2-GOV"
-  AGENT_IMAGE_NAME: "${{ github.repository }}/datadog-agent:${{ github.sha }}-7.57.2-GOV"
+  AGENT_VERSION: 7.58.1
+  CLUSTER_AGENT_IMAGE_NAME: "${{ github.repository }}/datadog-cluster-agent:${{ github.sha }}-7.58.1-GOV"
+  AGENT_IMAGE_NAME: "${{ github.repository }}/datadog-agent:${{ github.sha }}-7.58.1-GOV"
 
 jobs:
   build-and-scan:


### PR DESCRIPTION

        container datadog-agent/datadog-agent update
        * release from: 7.57.2
        * release to: 7.58.1

        Acceptance Criteria:
        * datadog-agent/datadog-agent build completes successfully with the new release
        